### PR TITLE
Fix changing url hash causing weird scroll behaviour

### DIFF
--- a/js/home.js
+++ b/js/home.js
@@ -1,87 +1,92 @@
 $(document).ready(function() {
-    $('li').click(function() {
-      target = $(this).attr('data');
-      section = $('#' + target);
-      offset = section.offset().top;
-      $('html, body').animate({
-        scrollTop: offset
-      },500);
-    });
-    
-  
-    
-  
-    $("#needHelp").click(function() {
-      $("#helpAdvice").show();
-      $("#overlay").show();
-      $("body").addClass("noscroll");
-    });
-    $("#dismiss, #overlay").click(function() {
-        $("#helpAdvice").hide();
-        $("#overlay").hide();
-        $("body").removeClass("noscroll");
-      });
-  
-  
-    $("#showfull").click(function() {
-      $(".schedule").hide();
-      $("#fullSchedule tr").show();
-      $(".col-problemsets, .col-type, .col-projects, .week").show();
-      $("#fullSchedule").show();
-      $(".schedule-firstrow").show();
-      
-  
-    })
-    $("#showlectures").click(function() {
-      $("#fullSchedule tr").hide();
-      $(".lectures").show();
-      $(".schedule-firstrow").show();
-      $(".schedule").hide();
-      $("#fullSchedule").show();
-      $(".col-problemsets, .col-type, .col-projects, .week").hide();
-    });
-    $("#showrecitations").click(function() {
-      $("#fullSchedule tr").hide();
-      $(".recitations").show();
-      $(".schedule-firstrow").show();
-      $(".schedule").hide();
-      $("#fullSchedule").show();
-      $(".col-problemsets, .col-type, .col-projects, .week").hide();
-    });
-  
-    $("#showquizzes").click(function() {
-      $(".schedule").hide();
-      $("#quizSchedule").show();
-    });
-    $("#showexams").click(function() {
-      $(".schedule").hide();
-      $("#examSchedule").show();
-    });
-    $("#showprojects").click(function() {
-      $(".schedule").hide();
-      $("#projectSchedule").show();
-    });
-    $("#showproblemsets").click(function() {
-      $(".schedule").hide();
-      $("#psSchedule").show();
-    });
-    $(document).on('scroll',function(e) {
-      /* highlighting the active section */
-      $('li').removeClass('active');
-      datahash = window.location.hash.split("#")[1];
-      element = "li[data='"+datahash+"']";
-      $("li[data='"+datahash+"']").addClass("active");
-  
-  
-      /* updating the hash for the active section */
-      $('section').each(function(){
-        if ( $(this).offset().top < window.pageYOffset + 40
-        &&   $(this).offset().top + 
-             $(this).height() > window.pageYOffset + 40) { 
-          var data = $(this).attr('id');
-          window.location.hash = data;
-        }
-      });
-    });
+  $('li').click(function() {
+    target = $(this).attr('data');
+    section = $('#' + target);
+    offset = section.offset().top;
+    $('html, body').animate({
+      scrollTop: offset
+    },500);
   });
   
+
+  
+
+  $("#needHelp").click(function() {
+    $("#helpAdvice").show();
+    $("#overlay").show();
+    $("body").addClass("noscroll");
+  });
+  $("#dismiss, #overlay").click(function() {
+      $("#helpAdvice").hide();
+      $("#overlay").hide();
+      $("body").removeClass("noscroll");
+    });
+
+
+  $("#showfull").click(function() {
+    $(".schedule").hide();
+    $("#fullSchedule tr").show();
+    $(".col-problemsets, .col-type, .col-projects, .week").show();
+    $("#fullSchedule").show();
+    $(".schedule-firstrow").show();
+    
+
+  })
+  $("#showlectures").click(function() {
+    $("#fullSchedule tr").hide();
+    $(".lectures").show();
+    $(".schedule-firstrow").show();
+    $(".schedule").hide();
+    $("#fullSchedule").show();
+    $(".col-problemsets, .col-type, .col-projects, .week").hide();
+  });
+  $("#showrecitations").click(function() {
+    $("#fullSchedule tr").hide();
+    $(".recitations").show();
+    $(".schedule-firstrow").show();
+    $(".schedule").hide();
+    $("#fullSchedule").show();
+    $(".col-problemsets, .col-type, .col-projects, .week").hide();
+  });
+
+  $("#showquizzes").click(function() {
+    $(".schedule").hide();
+    $("#quizSchedule").show();
+  });
+  $("#showexams").click(function() {
+    $(".schedule").hide();
+    $("#examSchedule").show();
+  });
+  $("#showprojects").click(function() {
+    $(".schedule").hide();
+    $("#projectSchedule").show();
+  });
+  $("#showproblemsets").click(function() {
+    $(".schedule").hide();
+    $("#psSchedule").show();
+  });
+  $(document).on('scroll',function(e) {
+    /* highlighting the active section */
+    $('li').removeClass('active');
+    datahash = window.location.hash.split("#")[1];
+
+    console.log(datahash)
+
+    
+    element = "li[data='"+datahash+"']";
+    $("li[data='"+datahash+"']").addClass("active");
+
+
+    /* updating the hash for the active section */
+    $('section').each(function(){
+      if ( $(this).offset().top < window.pageYOffset + 40
+      &&   $(this).offset().top + 
+           $(this).height() > window.pageYOffset + 40) { 
+        var data = $(this).attr('id');
+        
+        // this will prevent scrolling to the element that has the #data id when the url's hash is changed
+        history.replaceState({}, '', "#" + data);
+      }
+    });
+  });
+});

--- a/js/home.js
+++ b/js/home.js
@@ -69,9 +69,6 @@ $(document).ready(function() {
     /* highlighting the active section */
     $('li').removeClass('active');
     datahash = window.location.hash.split("#")[1];
-
-    console.log(datahash)
-
     
     element = "li[data='"+datahash+"']";
     $("li[data='"+datahash+"']").addClass("active");


### PR DESCRIPTION
**Problem**: when scrolling on PC browser, the functionality of changing the URL hash depending on which section the user is at makes scrolling behave weirdly, like sometimes the scrollbar stays stuck until moved manually by dragging it with the mouse.

**Solution**: using `history.replaceState()` instead of `window.location.hash` to prevent the browser from scrolling to the section corresponding to the new hash whenever the `scroll` event happens.

**Browser**: Firefox 108.01


**Demonstration video**
- Before (broken behavior):

https://user-images.githubusercontent.com/49586511/216850507-d7e46e18-0b5b-4248-a1aa-da1b9d302766.mp4

- After (fixed behavior):

https://user-images.githubusercontent.com/49586511/216850656-86e7b7ab-4916-4147-b894-7d5d21abe856.mp4


Anyway, I congratulate you for the website, it's a very good initiative from you to make things organized.


(I know I should be revising now, but the autism kicked in)